### PR TITLE
Update TabPFN URL in utils.py

### DIFF
--- a/TALENT/model/lib/tabpfn/utils.py
+++ b/TALENT/model/lib/tabpfn/utils.py
@@ -172,7 +172,7 @@ def load_model_workflow(i, e, add_name, base_path, device='cpu', eval_addition='
             print('We have to download the TabPFN, as there is no checkpoint at ', model_path)
             print('It has about 100MB, so this might take a moment.')
             import requests
-            url = 'https://github.com/automl/TabPFN/raw/main/tabpfn/models_diff/prior_diff_real_checkpoint_n_0_epoch_42.cpkt'
+            url = 'https://github.com/PriorLabs/TabPFN/raw/refs/tags/v1.0.0/tabpfn/models_diff/prior_diff_real_checkpoint_n_0_epoch_42.cpkt'
             print('hhh')
             r = requests.get(url, allow_redirects=True)
             print('hhh')


### PR DESCRIPTION
The downloader for the TabPFN model was pointing to an outdated URL. This commit updates it.